### PR TITLE
Fix default scoreboard setting

### DIFF
--- a/src/main/java/sir_draco/survivalskills/SurvivalSkills.java
+++ b/src/main/java/sir_draco/survivalskills/SurvivalSkills.java
@@ -473,11 +473,12 @@ public final class SurvivalSkills extends JavaPlugin {
 
     public void loadScoreboardSetting(UUID uuid, FileConfiguration data) {
         if (toggledScoreboard.containsKey(uuid)) return;
-        if (data.contains(uuid + ".Scoreboard")) {
+        if (!data.contains(uuid + ".Scoreboard")) {
+            // default to having the scoreboard enabled when no setting exists
             toggledScoreboard.put(uuid, true);
-            return;
+        } else {
+            toggledScoreboard.put(uuid, data.getBoolean(uuid + ".Scoreboard"));
         }
-        toggledScoreboard.put(uuid, data.getBoolean(uuid + ".Scoreboard"));
     }
 
     public void savePlayerData(Player p) {


### PR DESCRIPTION
## Summary
- fix scoreboard default logic in `loadScoreboardSetting`
- add comment describing the default behavior

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643fa1ad5c8326a6b151af57b0a2ed